### PR TITLE
fix: WalletConnect popup modal fix for Unsupported Network & No MetaMask

### DIFF
--- a/assets/linearLibrary/linearJs/lib/signers/walletConnectSigner.ts
+++ b/assets/linearLibrary/linearJs/lib/signers/walletConnectSigner.ts
@@ -38,12 +38,9 @@ const WalletConnectSigner = async (props: WalletConnectCofig) => {
     provider.connector.chainId != 0
   ) {
     await provider.disconnect();
-    window.$nuxt.$store.commit("setAutoConnect", false);
     window.$nuxt.$store.commit("setWalletConnect", {
-      uri: "https://www.investopedia.com/terms/q/quick-response-qr-code.asp",
       qrcode: false,
     });
-    window.$nuxt.$store.commit("setWalletType", "");
     return;
   } else {
     return UpdateWalletConnectSigner(provider);

--- a/assets/linearLibrary/linearJs/lib/signers/walletConnectSigner.ts
+++ b/assets/linearLibrary/linearJs/lib/signers/walletConnectSigner.ts
@@ -1,5 +1,6 @@
 import { providers } from "ethers";
 import WalletConnectProvider from "@walletconnect/web3-provider";
+import { SUPPORTED_NETWORKS } from "~/assets/linearLibrary/linearTools/network";
 
 interface WalletConnectCofig {
   infuraId?: string | undefined;
@@ -31,7 +32,22 @@ const WalletConnectSigner = async (props: WalletConnectCofig) => {
     });
   });
   await provider.enable();
-  return UpdateWalletConnectSigner(provider);
+  // if unsupported network then disconnect provider which allows the QR code to popup again
+  if (
+    !SUPPORTED_NETWORKS[provider.connector.chainId] &&
+    provider.connector.chainId != 0
+  ) {
+    await provider.disconnect();
+    window.$nuxt.$store.commit("setAutoConnect", false);
+    window.$nuxt.$store.commit("setWalletConnect", {
+      uri: "https://www.investopedia.com/terms/q/quick-response-qr-code.asp",
+      qrcode: false,
+    });
+    window.$nuxt.$store.commit("setWalletType", "");
+    return;
+  } else {
+    return UpdateWalletConnectSigner(provider);
+  }
 };
 
 export const UpdateWalletConnectSigner = (provider: any) => {

--- a/assets/linearLibrary/linearTools/lnrJSConnector.ts
+++ b/assets/linearLibrary/linearTools/lnrJSConnector.ts
@@ -147,7 +147,20 @@ const connectToWalletConnect = async () => {
         networkId: 1,
       });
       let signer = await signers.WalletConnect(walletConfig);
-      let provider = signer?.provider;
+      if (signer) {
+        let provider = signer.provider;
+        const accounts = await provider?.listAccounts();
+        if (provider && signer && accounts && accounts.length > 0) {
+          let network = await provider.getNetwork();
+          lnrJSConnector.setContractSettings(network.chainId, signer.signer);
+          return {
+            ...walletState,
+            currentWallet: accounts[0],
+            networkId: network.chainId,
+            networkName: network.name.toLowerCase(),
+          };
+        }
+      }
       //这里存在的原因是当enable时会改变chainId
       // let networkId = (await provider.getNetwork()).chainId;
       // 更新web3Provider,不然会出现调用合约方法出错的问题
@@ -155,18 +168,6 @@ const connectToWalletConnect = async () => {
       //     type: walletState.walletType,
       //     networkId,
       //   });
-
-      const accounts = await provider?.listAccounts();
-      if (provider && signer && accounts && accounts.length > 0) {
-        let network = await provider.getNetwork();
-        lnrJSConnector.setContractSettings(network.chainId, signer.signer);
-        return {
-          ...walletState,
-          currentWallet: accounts[0],
-          networkId: network.chainId,
-          networkName: network.name.toLowerCase(),
-        };
-      }
     }
   } catch (e) {
     console.log(e);

--- a/assets/linearLibrary/linearTools/lnrJSConnector.ts
+++ b/assets/linearLibrary/linearTools/lnrJSConnector.ts
@@ -147,19 +147,17 @@ const connectToWalletConnect = async () => {
         networkId: 1,
       });
       let signer = await signers.WalletConnect(walletConfig);
-      let provider = signer.provider;
-
+      let provider = signer?.provider;
       //这里存在的原因是当enable时会改变chainId
       // let networkId = (await provider.getNetwork()).chainId;
-
       // 更新web3Provider,不然会出现调用合约方法出错的问题
       //  updateWalletConnectWeb3Provider({
       //     type: walletState.walletType,
       //     networkId,
       //   });
 
-      const accounts = await provider.listAccounts();
-      if (accounts && accounts.length > 0) {
+      const accounts = await provider?.listAccounts();
+      if (provider && signer && accounts && accounts.length > 0) {
         let network = await provider.getNetwork();
         lnrJSConnector.setContractSettings(network.chainId, signer.signer);
         return {
@@ -194,7 +192,7 @@ const updateWalletConnectWeb3Provider = (props: Iprops) => {
 export const setSigner = async (props: Iprops) => {
   const walletConfig = getSignerConfig(props);
   const signer = await signers.WalletConnect(walletConfig);
-  lnrJSConnector.setContractSettings(Number(props.networkId), signer.provider);
+  lnrJSConnector.setContractSettings(Number(props.networkId), signer?.provider);
 };
 
 const getSignerConfig = (props: Iprops) => {

--- a/assets/linearLibrary/linearTools/lnrJSConnector.ts
+++ b/assets/linearLibrary/linearTools/lnrJSConnector.ts
@@ -149,8 +149,8 @@ const connectToWalletConnect = async () => {
       let signer = await signers.WalletConnect(walletConfig);
       if (signer) {
         let provider = signer.provider;
-        const accounts = await provider?.listAccounts();
-        if (provider && signer && accounts && accounts.length > 0) {
+        const accounts = await provider.listAccounts();
+        if (accounts && accounts.length > 0) {
           let network = await provider.getNetwork();
           lnrJSConnector.setContractSettings(network.chainId, signer.signer);
           return {

--- a/assets/linearLibrary/linearTools/network.ts
+++ b/assets/linearLibrary/linearTools/network.ts
@@ -227,7 +227,12 @@ export const ETHEREUM_CHAIN_OPTIONS: { [k: number]: any } = {
 
 export async function getEthereumNetwork() {
   const isMobile = window.$nuxt.$store.state?.isMobile;
-  if (!window.ethereum && !isMobile) {
+  const walletType = window.$nuxt.$store.state?.walletType;
+  if (
+    !window.ethereum &&
+    !isMobile &&
+    walletType != SUPPORTED_WALLETS.WALLET_CONNECT
+  ) {
     window.open(WALLET_EXTENSIONS.METAMASK);
     return {};
   }

--- a/components/landingPage/index.vue
+++ b/components/landingPage/index.vue
@@ -398,7 +398,8 @@ export default {
 
     async selectedWallet(walletType) {
       const status = await checkNetwork();
-      if (status) {
+      // if (status) {
+      if (status || walletType === SUPPORTED_WALLETS.WALLET_CONNECT) {
         await selectedWallet(walletType);
       } else {
         try {

--- a/components/landingPage/index.vue
+++ b/components/landingPage/index.vue
@@ -397,15 +397,15 @@ export default {
     },
 
     async selectedWallet(walletType) {
+      // commit here to check walletType before checking network, if it is walletConnect, will not popup Metamask installation when getEthereumNetwork()
+      this.$store.commit("setWalletType", walletType);
       const status = await checkNetwork();
-      // if (status) {
       if (status || walletType === SUPPORTED_WALLETS.WALLET_CONNECT) {
         await selectedWallet(walletType);
       } else {
         try {
           await addEthereumChain(SUPPORTED_NETWORKS_MAP.BSCMAINNET);
           this.$store.commit("setAutoConnect", true);
-          this.$store.commit("setWalletType", walletType);
           location.reload();
         } catch (error) {
           this.$store.commit("setSetupModal", true);


### PR DESCRIPTION
The PR solves the following issues:

Wallet Connect Popup not showing (showing add network popup modal instead via MetaMask) if MetaMask is not installed:
 1. Directing to MetaMask installation page when clicking Connect Wallet via WalletConnect if MetaMask is not installed
Connecting to WalletConnect button does not check if MetaMask is installed (therefore will not direct to MetaMask installation)

2. The QR Code Modal currently will not popup if connected to wrong network via WalletConnect (requires clearing cache)
WalletConnectSigner has an empty return if the network is not supported and the provider is disconnected, currently . 
Therefore added checking for provider and signer to see if provider has been injected through WalletConnectSigner. As a the empty return from previous statement will not inject a signer or provider. 