### PR TITLE
fix: adding check on liquidation to the wallet address changed watch

### DIFF
--- a/components/appPage/actions/homePage.vue
+++ b/components/appPage/actions/homePage.vue
@@ -121,7 +121,11 @@ export default {
   },
   watch: {
     isMobile() {},
-    walletAddress() {},
+    walletAddress(newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.checkLiquidation();
+      }
+    },
     multiCollateralValuesRatios() {},
   },
   computed: {

--- a/components/appPage/walletDetails/index.vue
+++ b/components/appPage/walletDetails/index.vue
@@ -927,7 +927,11 @@ export default {
   watch: {
     trackStatusChange() {},
     walletStatus() {},
-    walletAddress() {},
+    walletAddress(newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.checkLiquidation();
+      }
+    },
     abbreviateAddress() {},
     walletDetails(data) {},
     isEthereumNetwork() {},

--- a/components/attentionBox.vue
+++ b/components/attentionBox.vue
@@ -246,7 +246,11 @@ export default {
   },
   watch: {
     isMobile() {},
-    walletAddress() {},
+    walletAddress(newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.checkLiquidation();
+      }
+    },
     multiCollateralValuesRatios() {},
   },
   computed: {


### PR DESCRIPTION
adding check on liquidation to the wallet address changed watch so that it ensures it's being called. There's a pub sub method which is meant to handle this, but it's not being called in the callback. It seems as though the code was changed at some point to not rely on this callback, but the code was never cleaned up to account for it. An investigation or code cleanup would be required.